### PR TITLE
Use ApprovalTests in MiddyLogger tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -351,3 +351,6 @@ MigrationBackup/
 
 # serverless framework temporary files
 .serverless
+
+# Approval Tests backup files
+*.Approved.txt.bak

--- a/test/Voxel.MiddyNet.Tests/MiddyLoggerShould.LogEnrichWithExtraProperties.approved.txt
+++ b/test/Voxel.MiddyNet.Tests/MiddyLoggerShould.LogEnrichWithExtraProperties.approved.txt
@@ -1,0 +1,5 @@
+{
+  "Message": "hello world",
+  "Level": "Info",
+  "key": "value"
+}

--- a/test/Voxel.MiddyNet.Tests/MiddyLoggerShould.LogExtraProperties.approved.txt
+++ b/test/Voxel.MiddyNet.Tests/MiddyLoggerShould.LogExtraProperties.approved.txt
@@ -1,0 +1,5 @@
+{
+  "Message": "hello world",
+  "Level": "Info",
+  "key": "value"
+}

--- a/test/Voxel.MiddyNet.Tests/MiddyLoggerShould.LogExtraPropertiesWithObject.approved.txt
+++ b/test/Voxel.MiddyNet.Tests/MiddyLoggerShould.LogExtraPropertiesWithObject.approved.txt
@@ -1,0 +1,8 @@
+{
+  "Message": "hello world",
+  "Level": "Info",
+  "key": {
+    "Property1": "The value of property1",
+    "Property2": "The value of property2"
+  }
+}

--- a/test/Voxel.MiddyNet.Tests/MiddyLoggerShould.LogGlobalPropertiesAndExtraProperties.approved.txt
+++ b/test/Voxel.MiddyNet.Tests/MiddyLoggerShould.LogGlobalPropertiesAndExtraProperties.approved.txt
@@ -1,0 +1,6 @@
+{
+  "Message": "hello world",
+  "Level": "Info",
+  "key": "value",
+  "key2": "value2"
+}

--- a/test/Voxel.MiddyNet.Tests/MiddyLoggerShould.LogLevelAndMessage.approved.txt
+++ b/test/Voxel.MiddyNet.Tests/MiddyLoggerShould.LogLevelAndMessage.approved.txt
@@ -1,0 +1,4 @@
+{
+  "Message": "hello world",
+  "Level": "Debug"
+}

--- a/test/Voxel.MiddyNet.Tests/MiddyLoggerShould.cs
+++ b/test/Voxel.MiddyNet.Tests/MiddyLoggerShould.cs
@@ -1,43 +1,46 @@
 ﻿using Amazon.Lambda.Core;
+using ApprovalTests;
+using ApprovalTests.Reporters;
 using NSubstitute;
 using Xunit;
 
 namespace Voxel.MiddyNet.Tests
 {
+    [UseReporter(typeof(DiffReporter))]
     public class MiddyLoggerShould
     {
         [Fact]
         public void LogLevelAndMessage()
         {
             var lambdaLogger = Substitute.For<ILambdaLogger>();
+            var receivedLog = string.Empty;
+            lambdaLogger.Log(Arg.Do<string>(a => receivedLog = a));
 
             var logger = new MiddyLogger(lambdaLogger);
             logger.Log(LogLevel.Debug, "hello world");
-
-            lambdaLogger.Received().Log(Arg.Is(@"{
-  ""Message"": ""hello world"",
-  ""Level"": ""Debug""
-}"));
+            
+            Approvals.Verify(receivedLog);
         }
 
         [Fact]
         public void LogExtraProperties()
         {
             var lambdaLogger = Substitute.For<ILambdaLogger>();
+            var receivedLog = string.Empty;
+            lambdaLogger.Log(Arg.Do<string>(a => receivedLog = a));
 
             var logger = new MiddyLogger(lambdaLogger);
             logger.Log(LogLevel.Info, "hello world", new LogProperty("key", "value"));
-            lambdaLogger.Received().Log(Arg.Is(@"{
-  ""Message"": ""hello world"",
-  ""Level"": ""Info"",
-  ""key"": ""value""
-}"));
+            
+            Approvals.Verify(receivedLog);
         }
 
         [Fact]
         public void LogExtraPropertiesWithObject()
         {
             var lambdaLogger = Substitute.For<ILambdaLogger>();
+            var receivedLog = string.Empty;
+            lambdaLogger.Log(Arg.Do<string>(a => receivedLog = a));
             var classToLog = new ClassToLog
             {
                 Property1 = "The value of property1",
@@ -46,44 +49,35 @@ namespace Voxel.MiddyNet.Tests
 
             var logger = new MiddyLogger(lambdaLogger);
             logger.Log(LogLevel.Info, "hello world", new LogProperty("key", classToLog));
-            lambdaLogger.Received().Log(Arg.Is(@"{
-  ""Message"": ""hello world"",
-  ""Level"": ""Info"",
-  ""key"": {
-    ""Property1"": ""The value of property1"",
-    ""Property2"": ""The value of property2""
-  }
-}"));
+            
+            Approvals.Verify(receivedLog);
         }
 
         [Fact]
         public void LogEnrichWithExtraProperties()
         {
             var lambdaLogger = Substitute.For<ILambdaLogger>();
+            var receivedLog = string.Empty;
+            lambdaLogger.Log(Arg.Do<string>(a => receivedLog = a));
 
             var logger = new MiddyLogger(lambdaLogger);
             logger.EnrichWith(new LogProperty("key", "value"));
             logger.Log(LogLevel.Info, "hello world");
-            lambdaLogger.Received().Log(Arg.Is(@"{
-  ""Message"": ""hello world"",
-  ""Level"": ""Info"",
-  ""key"": ""value""
-}"));
+
+            Approvals.Verify(receivedLog);
         }
         [Fact]
         public void LogGlobalPropertiesAndExtraProperties()
         {
             var lambdaLogger = Substitute.For<ILambdaLogger>();
+            var receivedLog = string.Empty;
+            lambdaLogger.Log(Arg.Do<string>(a => receivedLog = a));
 
             var logger = new MiddyLogger(lambdaLogger);
             logger.EnrichWith(new LogProperty("key", "value"));
             logger.Log(LogLevel.Info, "hello world", new LogProperty("key2", "value2"));
-            lambdaLogger.Received().Log(Arg.Is(@"{
-  ""Message"": ""hello world"",
-  ""Level"": ""Info"",
-  ""key"": ""value"",
-  ""key2"": ""value2""
-}"));
+
+            Approvals.Verify(receivedLog);
         }
 
         internal class ClassToLog

--- a/test/Voxel.MiddyNet.Tests/MiddyLoggerShould.cs
+++ b/test/Voxel.MiddyNet.Tests/MiddyLoggerShould.cs
@@ -9,13 +9,17 @@ namespace Voxel.MiddyNet.Tests
     [UseReporter(typeof(DiffReporter))]
     public class MiddyLoggerShould
     {
+        private readonly ILambdaLogger lambdaLogger = Substitute.For<ILambdaLogger>();
+        private string receivedLog = string.Empty;
+
+        public MiddyLoggerShould()
+        {
+            lambdaLogger.Log(Arg.Do<string>(a => receivedLog = a));
+        }
+
         [Fact]
         public void LogLevelAndMessage()
         {
-            var lambdaLogger = Substitute.For<ILambdaLogger>();
-            var receivedLog = string.Empty;
-            lambdaLogger.Log(Arg.Do<string>(a => receivedLog = a));
-
             var logger = new MiddyLogger(lambdaLogger);
             logger.Log(LogLevel.Debug, "hello world");
             
@@ -25,10 +29,6 @@ namespace Voxel.MiddyNet.Tests
         [Fact]
         public void LogExtraProperties()
         {
-            var lambdaLogger = Substitute.For<ILambdaLogger>();
-            var receivedLog = string.Empty;
-            lambdaLogger.Log(Arg.Do<string>(a => receivedLog = a));
-
             var logger = new MiddyLogger(lambdaLogger);
             logger.Log(LogLevel.Info, "hello world", new LogProperty("key", "value"));
             
@@ -38,9 +38,6 @@ namespace Voxel.MiddyNet.Tests
         [Fact]
         public void LogExtraPropertiesWithObject()
         {
-            var lambdaLogger = Substitute.For<ILambdaLogger>();
-            var receivedLog = string.Empty;
-            lambdaLogger.Log(Arg.Do<string>(a => receivedLog = a));
             var classToLog = new ClassToLog
             {
                 Property1 = "The value of property1",
@@ -56,10 +53,6 @@ namespace Voxel.MiddyNet.Tests
         [Fact]
         public void LogEnrichWithExtraProperties()
         {
-            var lambdaLogger = Substitute.For<ILambdaLogger>();
-            var receivedLog = string.Empty;
-            lambdaLogger.Log(Arg.Do<string>(a => receivedLog = a));
-
             var logger = new MiddyLogger(lambdaLogger);
             logger.EnrichWith(new LogProperty("key", "value"));
             logger.Log(LogLevel.Info, "hello world");
@@ -69,10 +62,6 @@ namespace Voxel.MiddyNet.Tests
         [Fact]
         public void LogGlobalPropertiesAndExtraProperties()
         {
-            var lambdaLogger = Substitute.For<ILambdaLogger>();
-            var receivedLog = string.Empty;
-            lambdaLogger.Log(Arg.Do<string>(a => receivedLog = a));
-
             var logger = new MiddyLogger(lambdaLogger);
             logger.EnrichWith(new LogProperty("key", "value"));
             logger.Log(LogLevel.Info, "hello world", new LogProperty("key2", "value2"));

--- a/test/Voxel.MiddyNet.Tests/Voxel.MiddyNet.Tests.csproj
+++ b/test/Voxel.MiddyNet.Tests/Voxel.MiddyNet.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ApprovalTests" Version="5.4.3" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />


### PR DESCRIPTION
MiddyLogger tests changed to use ApprovalTests to prevent them from failing due to some strange behavior in some computers.