### PR TITLE
Force APIGatewayProxyResponse as response

### DIFF
--- a/samples/ApiGatewayTracing/Voxel.MiddyNet.ApiGatewayTracingSample/ApiGatewayTracing.cs
+++ b/samples/ApiGatewayTracing/Voxel.MiddyNet.ApiGatewayTracingSample/ApiGatewayTracing.cs
@@ -10,7 +10,7 @@ namespace Voxel.MiddyNet.ApiGatewayTracingSample
     {
         public ApiGatewayTracing()
         {
-            Use(new ApiGatewayTracingMiddleware<APIGatewayProxyResponse>());
+            Use(new ApiGatewayTracingMiddleware());
         }
 
         protected override Task<APIGatewayProxyResponse> Handle(APIGatewayProxyRequest proxyRequest, MiddyNetContext context)

--- a/src/Voxel.MiddyNet.Tracing.ApiGatewayMiddleware/ApiGatewayTracingMiddleware.cs
+++ b/src/Voxel.MiddyNet.Tracing.ApiGatewayMiddleware/ApiGatewayTracingMiddleware.cs
@@ -5,7 +5,7 @@ using Voxel.MiddyNet.Tracing.Core;
 
 namespace Voxel.MiddyNet.Tracing.ApiGatewayMiddleware
 {
-    public class ApiGatewayTracingMiddleware<TRes> : ILambdaMiddleware<APIGatewayProxyRequest, TRes>
+    public class ApiGatewayTracingMiddleware : ILambdaMiddleware<APIGatewayProxyRequest, APIGatewayProxyResponse>
     {
         private const string TraceParentHeaderName = "traceparent";
         private const string TraceStateHeaderName = "tracestate";
@@ -30,7 +30,7 @@ namespace Voxel.MiddyNet.Tracing.ApiGatewayMiddleware
             return Task.CompletedTask;
         }
 
-        public Task<TRes> After(TRes lambdaResponse, MiddyNetContext context)
+        public Task<APIGatewayProxyResponse> After(APIGatewayProxyResponse lambdaResponse, MiddyNetContext context)
         {
             return Task.FromResult(lambdaResponse);
         }

--- a/test/Voxel.MiddyNet.Tracing.ApiGatewayMiddleware.Tests/ApiGatewayTracingMiddlewareShould.cs
+++ b/test/Voxel.MiddyNet.Tracing.ApiGatewayMiddleware.Tests/ApiGatewayTracingMiddlewareShould.cs
@@ -15,7 +15,7 @@ namespace Voxel.MiddyNet.Tracing.ApiGatewayMiddleware.Tests
             var logger = Substitute.For<IMiddyLogger>();
             var context = new MiddyNetContext(Substitute.For<ILambdaContext>(), _ => logger);
 
-            var middleware = new ApiGatewayTracingMiddleware<int>();
+            var middleware = new ApiGatewayTracingMiddleware();
 
             var apiGatewayEvent = new APIGatewayProxyRequest
             {


### PR DESCRIPTION
Force APIGatewayProxyResponse as a type for the response of the middleware.