### PR TITLE
Middy with exceptions

### DIFF
--- a/src/Voxel.MiddyNet.SSM/SSMMiddleware.cs
+++ b/src/Voxel.MiddyNet.SSM/SSMMiddleware.cs
@@ -51,7 +51,7 @@ namespace Voxel.MiddyNet.SSM
                         }
                         catch (Exception ex)
                         {
-                            context.MiddlewareExceptions.Add(ex);
+                            context.MiddlewareBeforeExceptions.Add(ex);
                         }
                     }
                 }

--- a/src/Voxel.MiddyNet/MiddyNet.cs
+++ b/src/Voxel.MiddyNet/MiddyNet.cs
@@ -17,7 +17,7 @@ namespace Voxel.MiddyNet
 
             await ExecuteBeforeMiddlewares(lambdaEvent);
 
-            var response = await HandleLambdaEvent(lambdaEvent);
+            var response = await SafeHandleLambdaEvent(lambdaEvent);
 
             MiddyContext.FinishedBeforeMiddlewares();
 
@@ -28,7 +28,7 @@ namespace Voxel.MiddyNet
             return response;
         }
 
-        private async Task<TRes> HandleLambdaEvent(TReq lambdaEvent)
+        private async Task<TRes> SafeHandleLambdaEvent(TReq lambdaEvent)
         {
             TRes response = default(TRes);
             try
@@ -89,11 +89,13 @@ namespace Voxel.MiddyNet
             }
             else
             {
-                MiddyContext.FinishedBeforeMiddlewares();
                 MiddyContext.AttachToLambdaContext(context);
             }
 
             MiddyContext.AdditionalContext.Clear(); //  Given that the instance is reused, we need to clean the dictionary.
+            MiddyContext.MiddlewareBeforeExceptions = new List<Exception>();
+            MiddyContext.HandlerException = null;
+            MiddyContext.MiddlewareAfterExceptions = null;
         }
 
         public MiddyNet<TReq, TRes> Use(ILambdaMiddleware<TReq, TRes> middleware)

--- a/src/Voxel.MiddyNet/MiddyNetContext.cs
+++ b/src/Voxel.MiddyNet/MiddyNetContext.cs
@@ -8,13 +8,15 @@ namespace Voxel.MiddyNet
     {
         public ILambdaContext LambdaContext { get; private set; }
         public IDictionary<string, object> AdditionalContext { get; }
-        public List<Exception> MiddlewareExceptions { get; set; }
+        public List<Exception> MiddlewareBeforeExceptions { get; internal set; }
+        public List<Exception> MiddlewareAfterExceptions { get; internal set; }
+        public Exception HandlerException { get; internal set; }
         public IMiddyLogger Logger { get; private set; }
 
         public MiddyNetContext(ILambdaContext context)
         {
             AdditionalContext = new Dictionary<string, object>();
-            MiddlewareExceptions = new List<Exception>();
+            MiddlewareBeforeExceptions = new List<Exception>();
             LoggerFactory = logger => new MiddyLogger(logger);
             AttachToLambdaContext(context);
         }
@@ -22,7 +24,7 @@ namespace Voxel.MiddyNet
         public MiddyNetContext(ILambdaContext context, Func<ILambdaLogger, IMiddyLogger> loggerFactory )
         {
             AdditionalContext = new Dictionary<string, object>();
-            MiddlewareExceptions = new List<Exception>();
+            MiddlewareBeforeExceptions = new List<Exception>();
             LoggerFactory = loggerFactory;
 
             AttachToLambdaContext(context);
@@ -35,5 +37,11 @@ namespace Voxel.MiddyNet
         }
 
         public Func<ILambdaLogger, IMiddyLogger> LoggerFactory { get; }
+
+        internal void FinishedBeforeMiddlewares()
+        {
+            MiddlewareAfterExceptions = new List<Exception>();
+            MiddlewareBeforeExceptions = null; // We assume that the function has handled the exceptions Before middlewares might have thrown
+        }
     }
 }

--- a/test/Voxel.MiddyNet.SSM.Tests/IntegrationTests.cs
+++ b/test/Voxel.MiddyNet.SSM.Tests/IntegrationTests.cs
@@ -119,9 +119,9 @@ namespace Voxel.MiddyNet.SSM.Tests
 
         protected override Task<string[]> Handle(int lambdaEvent, MiddyNetContext context)
         {
-            if (context.MiddlewareExceptions.Any())
+            if (context.MiddlewareBeforeExceptions.Any())
             {
-                return Task.FromResult(new[] {context.MiddlewareExceptions.First().ToString()});
+                return Task.FromResult(new[] {context.MiddlewareBeforeExceptions.First().ToString()});
             }
             
             var results = ParametersToGet.Select(n => context.AdditionalContext[n].ToString()).ToArray();

--- a/test/Voxel.MiddyNet.Tests/MiddyNetShould.cs
+++ b/test/Voxel.MiddyNet.Tests/MiddyNetShould.cs
@@ -30,7 +30,7 @@ namespace Voxel.MiddyNet.Tests
                 Exceptions = exceptions ?? new List<Exception>();
                 for (var i = 0; i < numberOfMiddlewares; i++)
                 {
-                    Use(new TestBeforeMiddleware(logLines, i+1, withFailingMiddleware));
+                    Use(new TestBeforeMiddleware(logLines, i + 1, withFailingMiddleware));
                     Use(new TestAfterMiddleware(logLines, i + 1, withFailingMiddleware));
                 }
 


### PR DESCRIPTION
Se separan las posibles excepciones en 3 propiedades del contexto: 
* Excepciones en Before
* Excepción en el Handle
* Excepciones en After

Se lanza en el after el agregado de Excepción Handle + Excepciones After. Las del Before se asume que han sido manejadas en el Handle.

En los Before, la colección de Excepciones After y la Excepcde Handle son nulos.
En los After, la colección de los Before es nula.
