### PR TITLE
Middy with exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Middy .NET is a lightwave middleware library for AWS Lambda and .NET Core 3.1. I
 
 It allows you to inject middlewares into your lambda functions so that your code is entirely focused on business logic. 
 
-Middlewares are published as separate NuGet packages (one NuGet for middleware) so that your lambda package can be as small as possible.
+Middlewares are published as separate NuGet packages (one NuGet per middleware) so that your lambda package can be as small as possible.
 
 For project documentation, please visit [readthedocs](https://voxelmiddynet.readthedocs.io).
 
@@ -27,7 +27,7 @@ Tests are written using xUnit and NSubstitute. There are some integration tests 
 3. Run tests using VS embedded Tests Window or with this command: `dotnet test` under the test project folder
 
 ## Usage
-This library will force you to organize your lambda functions in a certain way, although we think this way it's quite convenient. Each lambda will reside in it's own file and the exposed function will always be called `Handler`. All functions will have an input event and an output, although your system might ignore the output. An example of using the library with the SSM middleware will look like this:
+This library will force you to organize your lambda functions in a certain way, although we think this way is quite convenient. Each lambda will reside in it's own file and the exposed function will always be called `Handler`. All functions will have an input event and an output, although your system might ignore the output. An example of using the library with the SSM middleware will look like this:
 
 ```
 public class ForwardEmail : MiddyNet<SNSEvent, int>
@@ -73,12 +73,15 @@ After your code is executed, Middy .NET will call the after methods of the middl
 Errors can happen in the `Before` method of the middleware or in the `After` method of them. Although we capture those errors, we treat those them slightly different.
 
 #### Errors on Before
-When an exception is thrown by a middleware in the `Before` method, the exception is captured and added to the `MiddlewareExceptions` list, so that the following middlewares and the function can react to it.
+When an exception is thrown by a middleware in the `Before` method, the exception is captured and added to the `MiddlewareBeforeExceptions` list, so that the following middlewares and the function can react to it.
 
-After the `Handle` function is called and before the `After` middlewares are called, this list is cleared.
+#### Errors on Handler
+When an exception is thrown by the function in its `Handle` method and before the `After` middlewares are called, the exception is captured in the `HandlerException` property of the context, so that the following middlewares can react to it.
 
 #### Errors on After
-When an exception is thrown by a middleware in the `After` method, the exception is captured and added to the `MiddlewareExceptions` list, so that the following middlewares can reacto to it. When all the middlewares have run, if this list has any item, an `AggregateException` with all of them is thrown.
+When an exception is thrown by a middleware in the `After` method, the exception is captured and added to the `MiddlewareAfterExceptions` list, so that the following middlewares can react to it.
+
+When all the middlewares have run, if these lists or property have any items, an `AggregateException` with all of them is thrown.
 
 ## How to write a middleware
 To write a new Middleware, you just need to implement the interface `ILambdaMiddleware` and implement the `Before` and `After` methods, although normally you will only implement one of them. If you need to store data so that the `Handle` method can use it, you can use the `AdditionalContext` dictionary inside the `MiddyContext` object.

--- a/src/Voxel.MiddyNet.SSM/SSMMiddleware.cs
+++ b/src/Voxel.MiddyNet.SSM/SSMMiddleware.cs
@@ -51,7 +51,7 @@ namespace Voxel.MiddyNet.SSM
                         }
                         catch (Exception ex)
                         {
-                            context.MiddlewareExceptions.Add(ex);
+                            context.MiddlewareBeforeExceptions.Add(ex);
                         }
                     }
                 }

--- a/src/Voxel.MiddyNet/MiddyNet.cs
+++ b/src/Voxel.MiddyNet/MiddyNet.cs
@@ -85,7 +85,7 @@ namespace Voxel.MiddyNet
                 MiddyContext.AttachToLambdaContext(context);
             }
 
-            MiddyContext.Clear(); //  Given that the instance is reused, we need to clean the context.
+            MiddyContext.Clear(); // Given that the instance is reused, we need to clean the context.
         }
 
         public MiddyNet<TReq, TRes> Use(ILambdaMiddleware<TReq, TRes> middleware)

--- a/src/Voxel.MiddyNet/MiddyNet.cs
+++ b/src/Voxel.MiddyNet/MiddyNet.cs
@@ -85,7 +85,7 @@ namespace Voxel.MiddyNet
                 MiddyContext.AttachToLambdaContext(context);
             }
 
-            MiddyContext.Clear();
+            MiddyContext.Clear(); //  Given that the instance is reused, we need to clean the context.
         }
 
         public MiddyNet<TReq, TRes> Use(ILambdaMiddleware<TReq, TRes> middleware)

--- a/src/Voxel.MiddyNet/MiddyNet.cs
+++ b/src/Voxel.MiddyNet/MiddyNet.cs
@@ -17,7 +17,7 @@ namespace Voxel.MiddyNet
 
             await ExecuteBeforeMiddlewares(lambdaEvent);
 
-            var response = await HandleLambdaEvent(lambdaEvent);
+            var response = await SafeHandleLambdaEvent(lambdaEvent);
 
             MiddyContext.FinishedBeforeMiddlewares();
 
@@ -28,7 +28,7 @@ namespace Voxel.MiddyNet
             return response;
         }
 
-        private async Task<TRes> HandleLambdaEvent(TReq lambdaEvent)
+        private async Task<TRes> SafeHandleLambdaEvent(TReq lambdaEvent)
         {
             TRes response = default(TRes);
             try
@@ -89,11 +89,13 @@ namespace Voxel.MiddyNet
             }
             else
             {
-                MiddyContext.FinishedBeforeMiddlewares();
                 MiddyContext.AttachToLambdaContext(context);
             }
 
             MiddyContext.AdditionalContext.Clear(); //  Given that the instance is reused, we need to clean the dictionary.
+            MiddyContext.MiddlewareBeforeExceptions = new List<Exception>();
+            MiddyContext.HandlerException = null;
+            MiddyContext.MiddlewareAfterExceptions = null;
         }
 
         public MiddyNet<TReq, TRes> Use(ILambdaMiddleware<TReq, TRes> middleware)

--- a/src/Voxel.MiddyNet/MiddyNetContext.cs
+++ b/src/Voxel.MiddyNet/MiddyNetContext.cs
@@ -8,13 +8,15 @@ namespace Voxel.MiddyNet
     {
         public ILambdaContext LambdaContext { get; private set; }
         public IDictionary<string, object> AdditionalContext { get; }
-        public List<Exception> MiddlewareExceptions { get; set; }
+        public List<Exception> MiddlewareBeforeExceptions { get; internal set; }
+        public List<Exception> MiddlewareAfterExceptions { get; internal set; }
+        public Exception HandlerException { get; internal set; }
         public IMiddyLogger Logger { get; private set; }
 
         public MiddyNetContext(ILambdaContext context)
         {
             AdditionalContext = new Dictionary<string, object>();
-            MiddlewareExceptions = new List<Exception>();
+            MiddlewareBeforeExceptions = new List<Exception>();
             LoggerFactory = logger => new MiddyLogger(logger);
             AttachToLambdaContext(context);
         }
@@ -22,7 +24,7 @@ namespace Voxel.MiddyNet
         public MiddyNetContext(ILambdaContext context, Func<ILambdaLogger, IMiddyLogger> loggerFactory )
         {
             AdditionalContext = new Dictionary<string, object>();
-            MiddlewareExceptions = new List<Exception>();
+            MiddlewareBeforeExceptions = new List<Exception>();
             LoggerFactory = loggerFactory;
 
             AttachToLambdaContext(context);
@@ -35,5 +37,11 @@ namespace Voxel.MiddyNet
         }
 
         public Func<ILambdaLogger, IMiddyLogger> LoggerFactory { get; }
+
+        internal void FinishedBeforeMiddlewares()
+        {
+            MiddlewareAfterExceptions = new List<Exception>();
+            MiddlewareBeforeExceptions = null; // We assume that the function has handled the exceptions Before middlewares might have thrown
+        }
     }
 }

--- a/src/Voxel.MiddyNet/MiddyNetContext.cs
+++ b/src/Voxel.MiddyNet/MiddyNetContext.cs
@@ -29,8 +29,8 @@ namespace Voxel.MiddyNet
         {
             AdditionalContext = new Dictionary<string, object>();
             MiddlewareBeforeExceptions = new List<Exception>();
+            MiddlewareAfterExceptions = new List<Exception>();
             LoggerFactory = loggerFactory;
-
             AttachToLambdaContext(context);
         }
 

--- a/src/Voxel.MiddyNet/MiddyNetContext.cs
+++ b/src/Voxel.MiddyNet/MiddyNetContext.cs
@@ -51,7 +51,7 @@ namespace Voxel.MiddyNet
 
         public void Clear()
         {
-            AdditionalContext.Clear();
+            AdditionalContext.Clear();  //  Given that the instance is reused, we need to clean the dictionary.
             MiddlewareBeforeExceptions.Clear();
             HandlerException = null;
             MiddlewareAfterExceptions.Clear();

--- a/src/Voxel.MiddyNet/MiddyNetContext.cs
+++ b/src/Voxel.MiddyNet/MiddyNetContext.cs
@@ -51,7 +51,7 @@ namespace Voxel.MiddyNet
 
         public void Clear()
         {
-            AdditionalContext.Clear();  //  Given that the instance is reused, we need to clean the dictionary.
+            AdditionalContext.Clear();
             MiddlewareBeforeExceptions.Clear();
             HandlerException = null;
             MiddlewareAfterExceptions.Clear();

--- a/test/Voxel.MiddyNet.SSM.Tests/IntegrationTests.cs
+++ b/test/Voxel.MiddyNet.SSM.Tests/IntegrationTests.cs
@@ -119,9 +119,9 @@ namespace Voxel.MiddyNet.SSM.Tests
 
         protected override Task<string[]> Handle(int lambdaEvent, MiddyNetContext context)
         {
-            if (context.MiddlewareExceptions.Any())
+            if (context.MiddlewareBeforeExceptions.Any())
             {
-                return Task.FromResult(new[] {context.MiddlewareExceptions.First().ToString()});
+                return Task.FromResult(new[] {context.MiddlewareBeforeExceptions.First().ToString()});
             }
             
             var results = ParametersToGet.Select(n => context.AdditionalContext[n].ToString()).ToArray();

--- a/test/Voxel.MiddyNet.Tests/MiddyNetShould.cs
+++ b/test/Voxel.MiddyNet.Tests/MiddyNetShould.cs
@@ -30,7 +30,7 @@ namespace Voxel.MiddyNet.Tests
                 Exceptions = exceptions ?? new List<Exception>();
                 for (var i = 0; i < numberOfMiddlewares; i++)
                 {
-                    Use(new TestBeforeMiddleware(logLines, i+1, withFailingMiddleware));
+                    Use(new TestBeforeMiddleware(logLines, i + 1, withFailingMiddleware));
                     Use(new TestAfterMiddleware(logLines, i + 1, withFailingMiddleware));
                 }
 


### PR DESCRIPTION
- We store exceptions thrown by Before/Handle/After in separate properties.
- If any of those properties contains an exception, an aggregate exception is thrown with all of them.