### PR TITLE
Exceptions aggregate

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ When an exception is thrown by the function in its `Handle` method and before th
 #### Errors on After
 When an exception is thrown by a middleware in the `After` method, the exception is captured and added to the `MiddlewareAfterExceptions` list, so that the following middlewares can react to it.
 
-When all the middlewares have run, if these lists or property have any items, an `AggregateException` with all of them is thrown.
+When all the middlewares have run, if these lists or property have any items, an `AggregateException` with all of them is thrown unless there is only one exception in which case it throws an exception of that specific type.
 
 ## How to write a middleware
 To write a new Middleware, you just need to implement the interface `ILambdaMiddleware` and implement the `Before` and `After` methods, although normally you will only implement one of them. If you need to store data so that the `Handle` method can use it, you can use the `AdditionalContext` dictionary inside the `MiddyContext` object.

--- a/src/Voxel.MiddyNet/MiddyNet.cs
+++ b/src/Voxel.MiddyNet/MiddyNet.cs
@@ -22,7 +22,15 @@ namespace Voxel.MiddyNet
             response = await ExecuteAfterMiddlewares(response);
 
             if (MiddyContext.HasExceptions)
+            {
+                var exceptions = MiddyContext.GetAllExceptions();
+                if (exceptions.Count == 1)
+                {
+                    throw (dynamic)exceptions.Single();
+                }
                 throw new AggregateException(MiddyContext.GetAllExceptions());
+            }
+                
 
             return response;
         }

--- a/test/Voxel.MiddyNet.SSM.Tests/IntegrationTests.cs
+++ b/test/Voxel.MiddyNet.SSM.Tests/IntegrationTests.cs
@@ -47,8 +47,7 @@ namespace Voxel.MiddyNet.SSM.Tests
 
             Func<Task> act = async () => await lambda.Handler(1, new FakeLambdaContext());
 
-            act.Should().Throw<AggregateException>().Where(a =>
-                a.InnerExceptions.Count == 1 && a.InnerExceptions[0] is Amazon.SimpleSystemsManagement.Model.ParameterNotFoundException);
+            act.Should().Throw<Amazon.SimpleSystemsManagement.Model.ParameterNotFoundException>();
         }
     }
 


### PR DESCRIPTION
Middy was throwing always an Aggregate Exception even if only one exception had happened. We now throw that specific exception type in case of a single exception.