### PR TITLE
Update preview.yml

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -51,20 +51,5 @@ jobs:
       run: dotnet pack src/Voxel.MiddyNet.Tracing.SQSMiddleware/Voxel.MiddyNet.Tracing.SQSMiddleware.csproj -c $BUILD_CONFIG --version-suffix $VERSION_SUFFIX --no-build --include-source --include-symbols -o ./artifacts/Voxel.MiddyNet.Tracing.SQSMiddleware
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
-      with:
-        nuget-version: latest
-    - name: Publish Voxel.MiddyNet nuget
-      run: dotnet nuget push ./artifacts/Voxel.MiddyNet/*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
-    - name: Publish Voxel.MiddyNet.SSMMiddleware nuget
-      run: dotnet nuget push ./artifacts/Voxel.MiddyNet.SSMMiddleware/*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
-    - name: Publish Voxel.MiddyNet.Tracing.ApiGatewayMiddleware nuget
-      run: dotnet nuget push ./artifacts/Voxel.MiddyNet.Tracing.ApiGatewayMiddleware/*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
-    - name: Publish Voxel.Tracing.Core nuget
-      run: dotnet nuget push ./artifacts/Voxel.MiddyNet.Tracing.Core/*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
-    - name: Publish Voxel.MiddyNet.Tracing.SNS nuget
-      run: dotnet nuget push ./artifacts/Voxel.MiddyNet.Tracing.SNS/*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
-    - name: Publish Voxel.MiddyNet.Tracing.SNSMiddleware nuget
-      run: dotnet nuget push ./artifacts/Voxel.MiddyNet.Tracing.SNSMiddleware/*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
-    - name: Publish Voxel.MiddyNet.Tracing.SQSMiddleware nuget
-      run: dotnet nuget push ./artifacts/Voxel.MiddyNet.Tracing.SQSMiddleware/*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
+      
     

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,16 +3,12 @@ on:
   workflow_run:
     workflows: 
       - "MiddyNet Continuous Integration"
-    branches:
-      - main
     types:
       - completed
-    tags:       
-      - preview-*
 
 jobs:
   build:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && contains(github.ref, 'refs/tags/preview-')}}
   
     env:
       BUILD_CONFIG: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,20 +56,4 @@ jobs:
       run: dotnet pack src/Voxel.MiddyNet.Tracing.SQSMiddleware/Voxel.MiddyNet.Tracing.SQSMiddleware.csproj -c $BUILD_CONFIG --no-build --include-source --include-symbols -o ./artifacts/Voxel.MiddyNet.Tracing.SQSMiddleware
     - name: setup nuget
       uses: NuGet/setup-nuget@v1.0.5
-      with:
-        nuget-version: latest
-    - name: Publish Voxel.MiddyNet nuget
-      run: dotnet nuget push ./artifacts/Voxel.MiddyNet/*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
-    - name: Publish Voxel.MiddyNet.SSMMiddleware nuget
-      run: dotnet nuget push ./artifacts/Voxel.MiddyNet.SSMMiddleware/*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
-    - name: Publish Voxel.MiddyNet.Tracing.ApiGatewayMiddleware nuget
-      run: dotnet nuget push ./artifacts/Voxel.MiddyNet.Tracing.ApiGatewayMiddleware/*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
-    - name: Publish Voxel.Tracing.Core nuget
-      run: dotnet nuget push ./artifacts/Voxel.MiddyNet.Tracing.Core/*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
-    - name: Publish Voxel.MiddyNet.Tracing.SNS nuget
-      run: dotnet nuget push ./artifacts/Voxel.MiddyNet.Tracing.SNS/*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
-    - name: Publish Voxel.MiddyNet.Tracing.SNSMiddleware nuget
-      run: dotnet nuget push ./artifacts/Voxel.MiddyNet.Tracing.SNSMiddleware/*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
-    - name: Publish Voxel.MiddyNet.Tracing.SQSMiddleware nuget
-      run: dotnet nuget push ./artifacts/Voxel.MiddyNet.Tracing.SQSMiddleware/*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
-    
+      

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,16 +3,12 @@ on:
   workflow_run:
     workflows: 
       - "MiddyNet Continuous Integration"
-    branches:
-      - main
     types:
       - completed
-    tags:       
-      - release-*
 
 jobs:
   build:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && contains(github.ref, 'refs/tags/release-') }}
     
     env:
       BUILD_CONFIG: Release


### PR DESCRIPTION
Para cada build de CI completada ejecuta el job build del workflow preview.yml sólo si la CI ha ido bien y el push ha sido de un tag que comience por "preview-".
Lo mismo con el de release.yml.